### PR TITLE
Fix subtract_vectors function bug

### DIFF
--- a/src/vector_ops.py
+++ b/src/vector_ops.py
@@ -8,8 +8,7 @@ def add_vectors(x, y):
 
 def subtract_vectors(x, y):
     """Subtract two JAX arrays element-wise."""
-    # Intentional bug: using + instead of -
-    return x + y  # BUG: This should be x - y
+    return x - y
 
 
 def multiply_vectors(x, y):


### PR DESCRIPTION
Fixed the subtract_vectors function in src/vector_ops.py that was using addition (+) instead of subtraction (-). This resolves the test failure where the function was returning [6, 9, 12] instead of [4, 5, 6].

Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/code)